### PR TITLE
feat: add macos sqlite support and build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install dependencies (macOS)
       if: startsWith(matrix.os, 'macos')
       run: |
-        brew install cmake openssl glib libsecret
+        brew install cmake openssl sqlite3
 
     - name: Fetch xsimd
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,16 +3,20 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-
 project(deadbolt LANGUAGES CXX C)
 
 find_package(OpenSSL REQUIRED)
-
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(LIBSECRET REQUIRED libsecret-1)
-pkg_check_modules(GLIB REQUIRED glib-2.0)
 
-# Search simd paths
+# Check platform for key storage
+if(UNIX AND NOT APPLE)
+    pkg_check_modules(LIBSECRET REQUIRED libsecret-1)
+    pkg_check_modules(GLIB REQUIRED glib-2.0)
+elseif(APPLE)
+    find_package(SQLite3 REQUIRED)
+endif()
+
+# Search SIMD paths
 set(XSIMD_SEARCH_PATHS
     ${XSIMD_PATH}
     ${CMAKE_CURRENT_SOURCE_DIR}/external/xsimd
@@ -22,14 +26,13 @@ set(XSIMD_SEARCH_PATHS
     /usr/include/xsimd
 )
 
-# Find xsimd header
+# Find xsimd headers
 find_path(XSIMD_INCLUDE_DIR 
     NAMES xsimd/xsimd.hpp
     PATHS ${XSIMD_SEARCH_PATHS}
     PATH_SUFFIXES include
 )
 
-# Check if xsimd was found
 if(NOT XSIMD_INCLUDE_DIR)
     message(FATAL_ERROR "xsimd headers not found. Please specify XSIMD_PATH or ensure xsimd is installed.")
 endif()
@@ -37,6 +40,9 @@ endif()
 # Include directories
 set(INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+include_directories(${INCLUDE_DIR})
+
+# Optimization flags
 add_compile_options(-O3)
 
 # TOTP library
@@ -48,54 +54,50 @@ target_include_directories(totp PUBLIC
     ${XSIMD_INCLUDE_DIR}
     ${OPENSSL_INCLUDE_DIR}
 )
-target_link_libraries(totp PUBLIC 
-    OpenSSL::Crypto
-)
+target_link_libraries(totp PUBLIC OpenSSL::Crypto)
 
-# TOTP key storage with libsecret
-add_library(store STATIC 
-    ${INCLUDE_DIR}/store/store.c
-)
-target_include_directories(store PUBLIC 
-    ${INCLUDE_DIR}
-    ${LIBSECRET_INCLUDE_DIRS}
-    ${GLIB_INCLUDE_DIRS}
-)
-target_link_libraries(store PUBLIC 
-    ${LIBSECRET_LIBRARIES}
-    ${GLIB_LIBRARIES}
-)
+# Key Storage (Platform-Specific)
+# Libsecret/keyrings for Linux 
+if(UNIX AND NOT APPLE)
+    add_library(store STATIC ${INCLUDE_DIR}/store/store.c)
+    target_include_directories(store PUBLIC 
+        ${INCLUDE_DIR}
+        ${LIBSECRET_INCLUDE_DIRS}
+        ${GLIB_INCLUDE_DIRS}
+    )
+    target_link_libraries(store PUBLIC 
+        ${LIBSECRET_LIBRARIES}
+        ${GLIB_LIBRARIES}
+    )
+# SQLite implementation of keyring
+elseif(APPLE)
+    add_library(store STATIC ${INCLUDE_DIR}/store/store_sql.c)
+    target_include_directories(store PUBLIC 
+        ${INCLUDE_DIR}
+        ${SQLite3_INCLUDE_DIRS}
+    )
+    target_link_libraries(store PUBLIC SQLite::SQLite3)
+endif()
 
 # Parser library
-add_library(parser STATIC 
-    ${INCLUDE_DIR}/parser/parser.cpp
-)
-target_include_directories(parser PUBLIC 
-    ${INCLUDE_DIR}
-    ${XSIMD_INCLUDE_DIR}
-)
+add_library(parser STATIC ${INCLUDE_DIR}/parser/parser.cpp)
+target_include_directories(parser PUBLIC ${INCLUDE_DIR} ${XSIMD_INCLUDE_DIR})
+target_link_libraries(parser PUBLIC store totp)
 
 # Logger 
-add_library(logger ${INCLUDE_DIR}/logger/logger.cpp)
+add_library(logger STATIC ${INCLUDE_DIR}/logger/logger.cpp)
 
-target_link_libraries(parser PUBLIC 
-    store 
-    totp
-    logger
-)
-
-link_directories(${LIBSECRET_LIBRARY_DIRS} ${GLIB_LIBRARY_DIRS})
+# Link directories for Linux
+if(UNIX AND NOT APPLE)
+    link_directories(${LIBSECRET_LIBRARY_DIRS} ${GLIB_LIBRARY_DIRS})
+endif()
 
 # Main executable
 add_executable(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/src/cli.cpp)
 target_include_directories(${PROJECT_NAME} PRIVATE 
     ${INCLUDE_DIR}
-    ${LIBSECRET_INCLUDE_DIRS}
-    ${GLIB_INCLUDE_DIRS}
     ${XSIMD_INCLUDE_DIR}
     ${OPENSSL_INCLUDE_DIR}
-) 
-target_link_libraries(${PROJECT_NAME} PRIVATE 
-    parser
-    OpenSSL::Crypto
 )
+target_link_libraries(${PROJECT_NAME} PRIVATE parser OpenSSL::Crypto logger)
+

--- a/include/store/store.c
+++ b/include/store/store.c
@@ -1,3 +1,6 @@
+// Compile this source only for linux
+#ifdef __linux__
+
 #include "store.h"
 #include <libsecret/secret.h>
 #include <stdio.h>
@@ -130,3 +133,5 @@ int totp_delete_key(const char *service_name) {
   }
   return result ? 0 : 1;
 }
+
+#endif

--- a/include/store/store_sql.c
+++ b/include/store/store_sql.c
@@ -1,3 +1,6 @@
+// Compile this source only for MacOS
+#ifdef __APPLE__
+
 #include "store.h"
 #include <sqlite3.h>
 #include <stdio.h>
@@ -134,3 +137,4 @@ int totp_delete_key(const char *service_name) {
   return result;
 }
 
+#endif


### PR DESCRIPTION
Add support for `sqlite3` implementation of keyrings for macOS.
Note - This backend will be an optional backend for all OS, MacOS will receive a keychain (inbuilt mac keyring) support in the future.